### PR TITLE
refactor: extract shared logic in sequence validation, complement, and conversion

### DIFF
--- a/src/sequence/conversion.ts
+++ b/src/sequence/conversion.ts
@@ -2,6 +2,20 @@ import { DNA, unsafeDNA } from './DNA.js';
 import { RNA, unsafeRNA } from './RNA.js';
 
 /**
+ * Replaces all occurrences of one nucleotide character with another in a sequence string.
+ * Shared helper for sequence-level transcription and reverse transcription, avoiding
+ * duplication between the two conversion functions.
+ *
+ * @param sequence - Source sequence string
+ * @param from - Nucleotide character to replace
+ * @param to - Nucleotide character to replace with
+ * @returns The sequence with all occurrences replaced
+ */
+function replaceBase(sequence: string, from: string, to: string): string {
+  return sequence.replaceAll(from, to);
+}
+
+/**
  * Converts a {@link DNA} sequence to its {@link RNA} equivalent at the sequence level
  * (T replaced by U, all other bases preserved).
  *
@@ -21,7 +35,7 @@ import { RNA, unsafeRNA } from './RNA.js';
  * ```
  */
 export function transcribeSequence(dna: DNA): RNA {
-  return unsafeRNA(dna.sequence.replaceAll('T', 'U'));
+  return unsafeRNA(replaceBase(dna.sequence, 'T', 'U'));
 }
 
 /**
@@ -42,5 +56,5 @@ export function transcribeSequence(dna: DNA): RNA {
  * ```
  */
 export function reverseTranscribeSequence(rna: RNA): DNA {
-  return unsafeDNA(rna.sequence.replaceAll('U', 'T'));
+  return unsafeDNA(replaceBase(rna.sequence, 'U', 'T'));
 }

--- a/src/sequence/internal-nucleic-acid-impl.ts
+++ b/src/sequence/internal-nucleic-acid-impl.ts
@@ -163,6 +163,15 @@ export abstract class NucleicAcidImpl<Self extends NucleicAcidImpl<Self>> {
   }
 }
 
+/**
+ * Computes the complement of each base in a sequence string using the provided map.
+ * Iterates forward (5' to 3') and replaces each base with its Watson-Crick complement.
+ *
+ * @param sequence - Validated nucleic acid sequence string
+ * @param complementMap - Alphabet-specific base-to-complement mapping
+ * @returns The complemented sequence string
+ * @throws Error if an unmapped base is encountered (should never happen with validated input)
+ */
 function complementString(
   sequence: string,
   complementMap: Readonly<Record<string, string>>,
@@ -179,18 +188,23 @@ function complementString(
   return result;
 }
 
+/**
+ * Computes the reverse complement of a sequence string.
+ * The reverse complement is obtained by first computing the complement of each base,
+ * then reversing the resulting string. This is equivalent to reading the opposite
+ * strand from 5' to 3'.
+ *
+ * Implemented by complementing then reversing, which is clearer and avoids
+ * duplicating the complement lookup logic.
+ *
+ * @param sequence - Validated nucleic acid sequence string
+ * @param complementMap - Alphabet-specific base-to-complement mapping
+ * @returns The reverse-complemented sequence string
+ */
 function reverseComplementString(
   sequence: string,
   complementMap: Readonly<Record<string, string>>,
 ): string {
-  let result = '';
-  for (let i = sequence.length - 1; i >= 0; i--) {
-    const base = sequence.charAt(i);
-    const complement = complementMap[base];
-    if (complement === undefined) {
-      throw new Error(`Complement encountered invalid base '${base}' at index ${i}`);
-    }
-    result += complement;
-  }
-  return result;
+  const complemented = complementString(sequence, complementMap);
+  return complemented.split('').reverse().join('');
 }

--- a/src/sequence/internal-validation.ts
+++ b/src/sequence/internal-validation.ts
@@ -5,6 +5,30 @@ const VALID_DNA_BASES = new Set(['A', 'C', 'G', 'T']);
 const VALID_RNA_BASES = new Set(['A', 'C', 'G', 'U']);
 
 /**
+ * Shared validation logic for nucleic acid sequence strings.
+ * Normalizes to upper-case, then checks against the provided valid base set.
+ * Returns a structured error on failure using the provided prefix and error kind.
+ *
+ * @internal
+ */
+function validateNucleicAcidString<ErrorKind extends string>(
+  input: string,
+  validBases: ReadonlySet<string>,
+  emptyKind: ErrorKind,
+  invalidKind: ErrorKind,
+): Result<string, { kind: ErrorKind; chars?: readonly string[]; firstAt?: number }> {
+  if (input.length === 0) {
+    return failure({ kind: emptyKind } as { kind: ErrorKind; chars?: readonly string[]; firstAt?: number });
+  }
+  const normalized = input.toUpperCase();
+  const issue = findInvalidBases(normalized, validBases);
+  if (issue !== undefined) {
+    return failure({ kind: invalidKind, chars: issue.chars, firstAt: issue.firstAt } as { kind: ErrorKind; chars?: readonly string[]; firstAt?: number });
+  }
+  return success(normalized);
+}
+
+/**
  * Validates and normalizes a candidate DNA string. On success the `Result` carries the
  * upper-cased sequence; on failure it carries the structured {@link DNAError} naming the
  * offending characters and the index of the first one.
@@ -15,15 +39,7 @@ const VALID_RNA_BASES = new Set(['A', 'C', 'G', 'U']);
  * @returns `Result<string, DNAError>` carrying the normalized sequence on success
  */
 export function validateDNAString(input: string): Result<string, DNAError> {
-  if (input.length === 0) {
-    return failure({ kind: 'dna/empty-sequence' });
-  }
-  const normalized = input.toUpperCase();
-  const issue = findInvalidBases(normalized, VALID_DNA_BASES);
-  if (issue !== undefined) {
-    return failure({ kind: 'dna/invalid-characters', chars: issue.chars, firstAt: issue.firstAt });
-  }
-  return success(normalized);
+  return validateNucleicAcidString(input, VALID_DNA_BASES, 'dna/empty-sequence', 'dna/invalid-characters') as Result<string, DNAError>;
 }
 
 /**
@@ -37,15 +53,7 @@ export function validateDNAString(input: string): Result<string, DNAError> {
  * @returns `Result<string, RNAError>` carrying the normalized sequence on success
  */
 export function validateRNAString(input: string): Result<string, RNAError> {
-  if (input.length === 0) {
-    return failure({ kind: 'rna/empty-sequence' });
-  }
-  const normalized = input.toUpperCase();
-  const issue = findInvalidBases(normalized, VALID_RNA_BASES);
-  if (issue !== undefined) {
-    return failure({ kind: 'rna/invalid-characters', chars: issue.chars, firstAt: issue.firstAt });
-  }
-  return success(normalized);
+  return validateNucleicAcidString(input, VALID_RNA_BASES, 'rna/empty-sequence', 'rna/invalid-characters') as Result<string, RNAError>;
 }
 
 function findInvalidBases(


### PR DESCRIPTION
## Summary

Three DRY refactoring improvements in `src/sequence/` with **zero behavioral change**, proven safe by Regrets fingerprint-based regression testing.

## Changes

### 1. internal-validation.ts - Extract shared validation generic

Both validateDNAString and validateRNAString delegate to a shared validateNucleicAcidString() generic that accepts the valid base set and error kind strings as parameters, eliminating the duplicated empty-check + normalize + findInvalidBases pattern.

### 2. internal-nucleic-acid-impl.ts - Simplify reverse complement

reverseComplementString() is now expressed as complementString() + reverse, which is clearer and avoids duplicating the complement map lookup loop.

### 3. conversion.ts - Extract shared base replacement helper

Both transcribeSequence() and reverseTranscribeSequence() delegate to a shared replaceBase() helper, making the symmetric T/U replacement pattern explicit.

## Verification

- 781 existing tests: ALL PASS
- Regrets 10-cluster fingerprint validation: ALL GREEN
- Direct output vs pre-refactor ground truth: IDENTICAL
- Cross-fingerprint check: ALL MATCH

### KEBENARAN 1 vs Final Output (sample)

| Cluster | Input | Pre | Post | Match |
|---------|-------|-----|------|-------|
| parse-dna | ATCG | {ok:true,sequence:ATCG} | {ok:true,sequence:ATCG} | YES |
| transcribe | ATCG | {ok:true,rnaSequence:AUCG} | {ok:true,rnaSequence:AUCG} | YES |
| complement | ATCG | {ok:true,complement:TAGC} | {ok:true,complement:TAGC} | YES |
| reverse-complement | ATCG | {ok:true,reverseComplement:CGAT} | {ok:true,reverseComplement:CGAT} | YES |
| is-stop-codon | UAA | {isStop:true} | {isStop:true} | YES |
| amino-acid | AUG | {ok:true,name:Methionine} | {ok:true,name:Methionine} | YES |

### Fingerprint Before/After

| Cluster | Pre | Post | Match |
|---------|-----|------|-------|
| parse-dna | 5pv2sv9 | 5pv2sv9 | YES |
| parse-rna | 15iduau | 15iduau | YES |
| transcribe | 35u6gxb | 35u6gxb | YES |
| reverse-transcribe | 6cclg5y | 6cclg5y | YES |
| dna-complement | 56pcsw8 | 56pcsw8 | YES |
| dna-reverse-complement | 5h6l5th | 5h6l5th | YES |
| is-stop-codon | 188mw9r | 188mw9r | YES |
| amino-acid-by-codon | 1kp3jn9 | 1kp3jn9 | YES |
| validate-reading-frame | 2tidctb | 2tidctb | YES |
| double-stranded-dna | 555mk3s | 555mk3s | YES |